### PR TITLE
small-fixes-after-presentation-to-footer-and-add-water

### DIFF
--- a/src/components/Footer/style.css
+++ b/src/components/Footer/style.css
@@ -1,8 +1,13 @@
 .swiper-button-next:after,
 .swiper-button-prev:after {
-    font-size: 25px;
-    font-weight: 900;
-
+    font-size: 18px;
+    font-weight: 1000;
 }
-
-
+.swiper-button-next:after {
+    position: relative;
+    left: 18px;
+}
+.swiper-button-prev:after {
+    position: relative;
+    right: 18px;
+}

--- a/src/components/TodayAddWaterModal/TodayAddWaterModal.module.css
+++ b/src/components/TodayAddWaterModal/TodayAddWaterModal.module.css
@@ -126,7 +126,7 @@
   font-weight: 400;
   font-size: 16px;
   line-height: 125%;
-  text-align: center;
+  text-align: left;
   padding: 10px;
   border-radius: 5px;
   border: 1px solid #ddd;

--- a/src/components/TodayListModal/TodayListModal.module.css
+++ b/src/components/TodayListModal/TodayListModal.module.css
@@ -74,7 +74,8 @@
 .amount_selector {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* justify-content: space-between; */
+  gap: 7px;
   margin-top: 10px;
   margin-bottom: 24px;
 }
@@ -125,7 +126,7 @@
   font-weight: 400;
   font-size: 16px;
   line-height: 125%;
-  text-align: center;
+  text-align: left;
   padding: 10px;
   border-radius: 5px;
   border: 1px solid #ddd;

--- a/src/components/WaterRratioPanel/WaterRatioPanel.module.css
+++ b/src/components/WaterRratioPanel/WaterRatioPanel.module.css
@@ -109,6 +109,7 @@
 .btn:hover,
 .btn:focus {
   box-shadow: 0px 4px 14px 0px rgba(64, 123, 255, 0.54);
+  cursor:pointer;
 }
 
 .conteinerItems {


### PR DESCRIPTION
fixed previous and next arrows on Footer module with team members to not overlap with the text:
![image](https://github.com/user-attachments/assets/ab4362b5-7c39-4a87-8a0b-7605aff4cbb7)
fixed fields value text align to be everywhere left like on Figma on Add water component in two places:
![image](https://github.com/user-attachments/assets/8527c471-f38d-4bc7-956d-4972fa3992b0)
fixed Add water button to have cursor pointer when you put mouse on it
